### PR TITLE
feat: implement create appointment success screen

### DIFF
--- a/src/components/Layout/AppHeader/styles.ts
+++ b/src/components/Layout/AppHeader/styles.ts
@@ -3,11 +3,12 @@ import { getStatusBarHeight } from "react-native-iphone-x-helper";
 
 import Avatar from "~/components/Base/Avatar";
 
+import { AppHeaderProps } from "./types";
+
 export const HeaderContainer = styled.View<AppHeaderProps>`
   width: 100%;
   padding: 24px;
   padding-top: ${getStatusBarHeight() + 24}px;
-  display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;

--- a/src/components/Layout/AuthScreenLayout/styles.ts
+++ b/src/components/Layout/AuthScreenLayout/styles.ts
@@ -35,7 +35,6 @@ export const FooterButton = styled.TouchableOpacity`
   left: 0;
   right: 0;
   bottom: 0;
-  display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;

--- a/src/constants/appointments.ts
+++ b/src/constants/appointments.ts
@@ -1,5 +1,3 @@
-import { AppointmentType } from "~/shared/types/apiSchema";
-
 export const daysInWeekBusinessIntervalText = "Segunda à sexta";
 
 export const hoursInDayBusinessIntervalText = "8h às 18h";
@@ -9,6 +7,8 @@ export const APPOINTMENT_TYPE = {
   HAIR_WASHING: "HAIR_WASHING",
   CLASSIC_SHAVING: "CLASSIC_SHAVING",
 } as const;
+
+export type AppointmentType = keyof typeof APPOINTMENT_TYPE
 
 export const APPOINTMENT_TYPES_LIST = [
   {

--- a/src/hooks/useCreateAppointment/index.tsx
+++ b/src/hooks/useCreateAppointment/index.tsx
@@ -17,7 +17,10 @@ export const useCreateAppointment = () => {
     const {
       date,
       type,
-      providerId: provider_id,
+      provider: {
+        id: provider_id,
+        name: providerName,
+      },
     } = payload;
 
     api.post("/appointments", {
@@ -25,7 +28,10 @@ export const useCreateAppointment = () => {
       type,
       provider_id,
     })
-      .then(() => navigate(CREATE_APPOINTMENT_SUCCESS_ROUTE))
+      .then(() => navigate(CREATE_APPOINTMENT_SUCCESS_ROUTE, {
+        date,
+        providerName,
+      }))
       .catch(() => Alert.alert("Error", "Error while creating appointment, please, try again"))
       .finally(() => setLoading(false));
   }, [navigate]);

--- a/src/hooks/useCreateAppointment/types.ts
+++ b/src/hooks/useCreateAppointment/types.ts
@@ -1,7 +1,8 @@
-import { AppointmentType, User } from "~/shared/types/apiSchema";
+import { AppointmentType } from "~/constants/appointments";
+import { User } from "~/shared/types/apiSchema";
 
 export interface CreateAppointmentPayload {
   date: Date;
   type: AppointmentType;
-  providerId: User["id"];
+  provider: Pick<User, "id" | "name">;
 }

--- a/src/screens/CreateAppointment/AppointmentTypeList/types.ts
+++ b/src/screens/CreateAppointment/AppointmentTypeList/types.ts
@@ -1,4 +1,4 @@
-import { AppointmentType } from "~/shared/types/apiSchema";
+import { AppointmentType } from "~/constants/appointments";
 
 export interface AppointmentTypeListProps {
   selectedAppointmentType: AppointmentType;

--- a/src/screens/CreateAppointment/index.tsx
+++ b/src/screens/CreateAppointment/index.tsx
@@ -12,8 +12,8 @@ import { ScreenContainer, Title } from "~/styles/components";
 import theme from "~/styles/theme";
 import useProviders from "~/hooks/useProviders";
 import useDayAvailability from "~/hooks/useDayAvailability";
-import { APPOINTMENT_TYPES_LIST } from "~/constants/appointments";
-import { AppointmentType, User } from "~/shared/types/apiSchema";
+import { APPOINTMENT_TYPES_LIST, AppointmentType } from "~/constants/appointments";
+import { User } from "~/shared/types/apiSchema";
 
 import { useCreateAppointment } from "~/hooks/useCreateAppointment";
 import {
@@ -33,9 +33,9 @@ import AppointmentTypeList from "./AppointmentTypeList";
 const CreateAppointment: React.FC = () => {
   const { goBack } = useNavigation();
   const { loading: loadingProviders, providers } = useProviders();
-  const { providerId } = useRoute<CreateAppointmentScreenRouteProp>().params;
+  const { provider } = useRoute<CreateAppointmentScreenRouteProp>().params;
 
-  const [selectedProviderId, setSelectedProviderId] = useState(providerId);
+  const [selectedProviderId, setSelectedProviderId] = useState(provider.id);
   const [selectedAppointmentType, setSelectedAppointmentType] = useState(
     APPOINTMENT_TYPES_LIST[0].value,
   );
@@ -80,7 +80,10 @@ const CreateAppointment: React.FC = () => {
     createAppointment({
       date: setHours(selectedAppointmentDate, selectedAvailabilityHour),
       type: selectedAppointmentType,
-      providerId: selectedProviderId,
+      provider: {
+        ...provider,
+        id: selectedProviderId,
+      },
     });
   };
 

--- a/src/screens/CreateAppointment/types.ts
+++ b/src/screens/CreateAppointment/types.ts
@@ -2,7 +2,9 @@ import { RouteProp } from "@react-navigation/native";
 import { User } from "~/shared/types/apiSchema";
 
 export type CreateAppointmentScreenParamList = {
-  CreateAppointment: { providerId: User["id"] };
+  CreateAppointment: {
+     provider: Pick<User, "id" | "name">;
+    };
 };
 
 export type CreateAppointmentScreenRouteProp = RouteProp<CreateAppointmentScreenParamList, "CreateAppointment">;

--- a/src/screens/CreateAppointment/types.ts
+++ b/src/screens/CreateAppointment/types.ts
@@ -1,13 +1,13 @@
 import { RouteProp } from "@react-navigation/native";
 import { User } from "~/shared/types/apiSchema";
 
-export type CreateAppointmentScreenParamList = {
+export type CreateAppointmentScreenParamsList = {
   CreateAppointment: {
-     provider: Pick<User, "id" | "name">;
-    };
+    provider: Pick<User, "id" | "name">;
+  };
 };
 
-export type CreateAppointmentScreenRouteProp = RouteProp<CreateAppointmentScreenParamList, "CreateAppointment">;
+export type CreateAppointmentScreenRouteProp = RouteProp<CreateAppointmentScreenParamsList, "CreateAppointment">;
 
 export interface HorizontalFlatListItemProps {
   isSelected: boolean;

--- a/src/screens/CreateAppointmentSuccess/index.tsx
+++ b/src/screens/CreateAppointmentSuccess/index.tsx
@@ -1,6 +1,12 @@
-import React from "react";
-import Icon from "react-native-vector-icons/Feather";
+/* eslint-disable import/no-duplicates */
+import React, { useEffect } from "react";
+import { useNavigation, useRoute, useNavigationState } from "@react-navigation/native";
 import { useTheme } from "styled-components";
+import { format } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import Icon from "react-native-vector-icons/Feather";
+
+import { CREATE_APPOINTMENT_SUCCESS_ROUTE, DASHBOARD_ROUTE } from "~/router/routes";
 
 import {
   CreateAppointmentSuccessTitle,
@@ -9,9 +15,46 @@ import {
   CreateAppointmentSuccessContainer,
   CreateAppointmentSuccessDescription,
 } from "./styles";
+import { CreateAppointmentSuccessScreenRouteProp } from "./types";
 
 const CreateAppointmentSuccess: React.FC = () => {
   const theme = useTheme();
+
+  const { date, providerName } = useRoute<CreateAppointmentSuccessScreenRouteProp>().params;
+  const { reset } = useNavigation();
+  const navigationState = useNavigationState(state => state);
+
+  const formattedDate = format(
+    date,
+    "EEEE', dia' dd 'de' MMMM 'de' yyyy 'às' HH:mm'h'",
+    {
+      locale: ptBR,
+    },
+  );
+
+  const navigateToDashboard = () => {
+    reset({
+      index: 1,
+      routes: [
+        {
+          name: DASHBOARD_ROUTE,
+        },
+      ],
+    });
+  };
+
+  useEffect(() => {
+    const routes = navigationState.routes.filter(({ name }) => (
+      name === CREATE_APPOINTMENT_SUCCESS_ROUTE
+    ));
+
+    reset({
+      ...navigationState,
+      routes,
+      index: routes.length - 1,
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reset]);
 
   return (
     <CreateAppointmentSuccessContainer>
@@ -23,11 +66,17 @@ const CreateAppointmentSuccess: React.FC = () => {
         </CreateAppointmentSuccessTitle>
 
         <CreateAppointmentSuccessDescription>
-          Terça, dia 14 de março de 2020 às 12:00h
-          com Diego Fernandes
+          {formattedDate}
+          {" "}
+          com
+          {" "}
+          {providerName}
         </CreateAppointmentSuccessDescription>
 
-        <CreateAppointmentSuccessButton enabled>
+        <CreateAppointmentSuccessButton
+          onPress={navigateToDashboard}
+          enabled
+        >
           Ok
         </CreateAppointmentSuccessButton>
       </CreateAppointmentSuccessContent>

--- a/src/screens/CreateAppointmentSuccess/index.tsx
+++ b/src/screens/CreateAppointmentSuccess/index.tsx
@@ -1,5 +1,38 @@
 import React from "react";
+import Icon from "react-native-vector-icons/Feather";
+import { useTheme } from "styled-components";
 
-const CreateAppointmentSuccess: React.FC = () => <></>;
+import {
+  CreateAppointmentSuccessTitle,
+  CreateAppointmentSuccessButton,
+  CreateAppointmentSuccessContent,
+  CreateAppointmentSuccessContainer,
+  CreateAppointmentSuccessDescription,
+} from "./styles";
+
+const CreateAppointmentSuccess: React.FC = () => {
+  const theme = useTheme();
+
+  return (
+    <CreateAppointmentSuccessContainer>
+      <CreateAppointmentSuccessContent>
+        <Icon name="check" size={70} color={theme.colors.green} />
+
+        <CreateAppointmentSuccessTitle>
+          Agendamento concluído
+        </CreateAppointmentSuccessTitle>
+
+        <CreateAppointmentSuccessDescription>
+          Terça, dia 14 de março de 2020 às 12:00h
+          com Diego Fernandes
+        </CreateAppointmentSuccessDescription>
+
+        <CreateAppointmentSuccessButton enabled>
+          Ok
+        </CreateAppointmentSuccessButton>
+      </CreateAppointmentSuccessContent>
+    </CreateAppointmentSuccessContainer>
+  );
+};
 
 export default CreateAppointmentSuccess;

--- a/src/screens/CreateAppointmentSuccess/styles.ts
+++ b/src/screens/CreateAppointmentSuccess/styles.ts
@@ -10,7 +10,6 @@ export const CreateAppointmentSuccessContainer = styled(ScreenContainer).attrs({
     justifyContent: "center",
   },
 })`
-  display: flex;
   padding: 0 14px;
 `;
 

--- a/src/screens/CreateAppointmentSuccess/styles.ts
+++ b/src/screens/CreateAppointmentSuccess/styles.ts
@@ -1,0 +1,41 @@
+import styled from "styled-components/native";
+
+import Button from "~/components/Base/Button";
+import { Title, ScreenContainer } from "~/styles/components";
+
+export const CreateAppointmentSuccessContainer = styled(ScreenContainer).attrs({
+  contentContainerStyle: {
+    flexGrow: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+})`
+  display: flex;
+  padding: 0 14px;
+`;
+
+export const CreateAppointmentSuccessContent = styled.View`
+  align-items: center;
+  width: 100%;
+`;
+
+export const CreateAppointmentSuccessTitle = styled(Title)`
+  text-align: center;
+  max-width: 199px;
+  margin-top: 30px;
+`;
+
+export const CreateAppointmentSuccessDescription = styled.Text`
+  color: ${({ theme }) => theme.colors.grayLight};
+  font-size: 14px;
+  max-width: 265px;
+  font-family: 'RobotoSlab-Regular';
+  text-align: center;
+`;
+
+export const CreateAppointmentSuccessButton = styled(Button)`
+  width: 100%;
+  margin: auto;
+  max-width: 100px;
+  margin-top: 40px;
+`;

--- a/src/screens/CreateAppointmentSuccess/types.ts
+++ b/src/screens/CreateAppointmentSuccess/types.ts
@@ -1,0 +1,12 @@
+import { RouteProp } from "@react-navigation/native";
+
+import { User } from "~/shared/types/apiSchema";
+
+export type CreateAppointmentSuccessScreenParamList = {
+  CreateAppointment: {
+    date: Date;
+    providerName: User["name"];
+  };
+};
+
+export type CreateAppointmentSuccessScreenRouteProp = RouteProp<CreateAppointmentSuccessScreenParamList, "CreateAppointment">;

--- a/src/screens/CreateAppointmentSuccess/types.ts
+++ b/src/screens/CreateAppointmentSuccess/types.ts
@@ -2,11 +2,11 @@ import { RouteProp } from "@react-navigation/native";
 
 import { User } from "~/shared/types/apiSchema";
 
-export type CreateAppointmentSuccessScreenParamList = {
+export type CreateAppointmentSuccessScreenParamsList = {
   CreateAppointment: {
     date: Date;
     providerName: User["name"];
   };
 };
 
-export type CreateAppointmentSuccessScreenRouteProp = RouteProp<CreateAppointmentSuccessScreenParamList, "CreateAppointment">;
+export type CreateAppointmentSuccessScreenRouteProp = RouteProp<CreateAppointmentSuccessScreenParamsList, "CreateAppointment">;

--- a/src/screens/Dashboard/DashboardProvidersList/index.tsx
+++ b/src/screens/Dashboard/DashboardProvidersList/index.tsx
@@ -30,9 +30,14 @@ const ProviderItem: React.FC<ProviderItemProps> = ({ item }) => {
   const navigate = useNavigate();
   const theme = useContext(ThemeContext);
 
+  const { id, name } = item;
+
   return (
     <ProviderContainer onPress={navigate(CREATE_APPOINTMENT_ROUTE, {
-      providerId: item.id,
+      provider: {
+        id,
+        name,
+      },
     })}
     >
       <ProviderAvatar source={userAvatarURI} />

--- a/src/screens/Dashboard/DashboardProvidersList/styles.ts
+++ b/src/screens/Dashboard/DashboardProvidersList/styles.ts
@@ -36,7 +36,6 @@ export const ProviderName = styled.Text`
 `;
 
 export const ProviderSchedule = styled.View`
-  display: flex;
   margin-top: 6px;
   flex-direction: row;
   align-items: center;

--- a/src/screens/ForgotPassword/styles.ts
+++ b/src/screens/ForgotPassword/styles.ts
@@ -18,7 +18,6 @@ export const SignInButton = styled.TouchableOpacity`
   left: 0;
   right: 0;
   bottom: 0;
-  display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;

--- a/src/screens/SignIn/styles.ts
+++ b/src/screens/SignIn/styles.ts
@@ -28,7 +28,6 @@ export const CreateAccount = styled.TouchableOpacity`
   left: 0;
   right: 0;
   bottom: 0;
-  display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;

--- a/src/screens/SignUp/styles.ts
+++ b/src/screens/SignUp/styles.ts
@@ -18,7 +18,6 @@ export const SignInButton = styled.TouchableOpacity`
   left: 0;
   right: 0;
   bottom: 0;
-  display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;

--- a/src/shared/types/apiSchema.ts
+++ b/src/shared/types/apiSchema.ts
@@ -1,5 +1,3 @@
-import { APPOINTMENT_TYPE } from "~/constants/appointments";
-
 export interface User {
   id: number;
   name: string;
@@ -10,5 +8,3 @@ export interface DayAvailability {
   hour: number;
   available: boolean;
 }
-
-export type AppointmentType = keyof typeof APPOINTMENT_TYPE

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -9,6 +9,7 @@ const theme = {
     red: "#C53030",
     blackMedium: "#28262E",
     shape: "#3E3B47",
+    green: "#04D361",
   },
   fonts: {
     medium: "RobotoSlab-Medium",


### PR DESCRIPTION
## Description

Navigate the user to a success screen after creating an appointment. The user will see the appointment date as well as the provider name. After seeing the details, it's possible to go back to the dashboard by pressing the `"Ok"` button

## Implementation Styles

https://user-images.githubusercontent.com/48022589/107269064-cbc6bc00-6a27-11eb-9608-b5540ff315fa.mov
